### PR TITLE
Fix all open issues and some more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*~
+*.sw*
+*.#*
+\#*#
+
+attachments/
+entities.xml
+exportDescriptor.properties
+out/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Confluence space to github markdown pages
 Convert a confluence space export in XML format to github markdown pages
 
+## Installation Requirements
+
+Requires
+[xsltproc](https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home) to be
+installed, e.g. on Debian, Ubuntu or derivatives call with root
+permissions:
+
+```
+apt install xsltproc
+```
+
 ## To export a space from confluence
 1. In confluence, navigate to Space Tools / Content Tools / Export and choose XML format
 2. Download the export zip and unzip

--- a/generate.sh
+++ b/generate.sh
@@ -18,7 +18,7 @@ echo "Convert page xmls to github markdown"
 for PAGE_PATH in out/page-xml/*.xml; do 
    PAGE_XML=${PAGE_PATH##out/page-xml/}
    PAGE_MD=${PAGE_XML%%.xml}.md
-   xsltproc page.xsl "${PAGE_PATH}" > "out/wiki/${PAGE_MD}"
+   xsltproc --path . page.xsl "${PAGE_PATH}" > "out/wiki/${PAGE_MD}"
 done
 
 echo "Content generated to out/wiki"

--- a/generate.sh
+++ b/generate.sh
@@ -3,6 +3,8 @@
 # Generate github markdown pages from confluence export
 ########################################################################
 
+set -e
+
 echo "Creating output directories"
 mkdir -pv out/page-xml
 mkdir -pv out/wiki/images

--- a/page.dtd
+++ b/page.dtd
@@ -1,7 +1,7 @@
 <!--
  DTD for use with generated XML pages
 -->
-<!ENTITY nbsp   "">
+<!ENTITY nbsp   "&#160;">
 
 <!-- General Punctuation -->
 <!ENTITY hellip  "&#8230;">
@@ -11,6 +11,23 @@
 <!ENTITY rsquo   "&#8217;">
 <!ENTITY ldquo   "&#8220;">
 <!ENTITY rdquo   "&#8221;">
+<!ENTITY laquo   "&#171;">
+<!ENTITY raquo   "&#187;">
+<!ENTITY iquest  "&#191;">
+<!ENTITY bdquo   "&#8222;">
+<!ENTITY sbquo   "&#8218;">
+<!ENTITY bull    "&#8226;">
+<!ENTITY shy     "&#173;">
+<!ENTITY ne      "&#8800;">
+<!ENTITY ge      "&#8805;">
+
+<!-- Other special characters -->
+<!ENTITY times   "&#215;">
+<!ENTITY radic   "&#8730;">
+<!ENTITY euro    "&#8364;">
+<!ENTITY para    "&#8364;">
+<!ENTITY frac12  "&#189;">
+<!ENTITY frac14  "&#188;">
 
 <!-- Arrows -->
 <!ENTITY larr    "&#8592;">
@@ -19,3 +36,69 @@
 <!ENTITY darr    "&#8595;">
 <!ENTITY harr    "&#8596;">
 
+<!-- Umlauts and other common European special characters in HTML. -->
+<!ENTITY Agrave "&#192;">
+<!ENTITY Aacute "&#193;">
+<!ENTITY Acirc  "&#194;">
+<!ENTITY Atilde "&#195;">
+<!ENTITY Auml   "&#196;">
+<!ENTITY Aring  "&#197;">
+<!ENTITY Aelig  "&#198;">
+<!ENTITY Ccedil "&#199;">
+<!ENTITY Egrave "&#200;">
+<!ENTITY Eacute "&#201;">
+<!ENTITY Ecirc  "&#202;">
+<!ENTITY Euml   "&#203;">
+<!ENTITY Igrave "&#204;">
+<!ENTITY Iacute "&#205;">
+<!ENTITY Icirc  "&#206;">
+<!ENTITY Iuml   "&#207;">
+<!ENTITY ETH    "&#208;">
+<!ENTITY Ntilde "&#209;">
+<!ENTITY Ograve "&#210;">
+<!ENTITY Oacute "&#211;">
+<!ENTITY Ocirc  "&#212;">
+<!ENTITY Otilde "&#213;">
+<!ENTITY Ouml   "&#214;">
+<!ENTITY Oslash "&#216;">
+<!ENTITY Ugrave "&#217;">
+<!ENTITY Uacute "&#218;">
+<!ENTITY Ucirc  "&#219;">
+<!ENTITY Uuml   "&#220;">
+<!ENTITY Yacute "&#221;">
+<!ENTITY THORN  "&#222;">
+<!ENTITY szlig  "&#223;">
+<!ENTITY agrave "&#224;">
+<!ENTITY aacute "&#225;">
+<!ENTITY acirc  "&#226;">
+<!ENTITY atilde "&#227;">
+<!ENTITY auml   "&#228;">
+<!ENTITY aring  "&#229;">
+<!ENTITY aelig  "&#230;">
+<!ENTITY ccedil "&#231;">
+<!ENTITY egrave "&#232;">
+<!ENTITY eacute "&#233;">
+<!ENTITY ecirc  "&#234;">
+<!ENTITY euml   "&#235;">
+<!ENTITY igrave "&#236;">
+<!ENTITY iacute "&#237;">
+<!ENTITY icirc  "&#238;">
+<!ENTITY iuml   "&#239;">
+<!ENTITY eth    "&#240;">
+<!ENTITY ntilde "&#241;">
+<!ENTITY ograve "&#242;">
+<!ENTITY oacute "&#243;">
+<!ENTITY ocirc  "&#244;">
+<!ENTITY otilde "&#245;">
+<!ENTITY ouml   "&#246;">
+<!ENTITY oslash "&#248;">
+<!ENTITY ugrave "&#249;">
+<!ENTITY uacute "&#250;">
+<!ENTITY ucirc  "&#251;">
+<!ENTITY uuml   "&#252;">
+<!ENTITY yacute "&#253;">
+<!ENTITY thorn  "&#254;">
+<!ENTITY yuml   "&#255;">
+<!ENTITY sup1   "&#185;">
+<!ENTITY sup2   "&#178;">
+<!ENTITY sup3   "&#179;">


### PR DESCRIPTION
Hi,

these commits fix #1 and #2, add a `.gitignore` file to ignore the Confluence export files as well as common editor backup files (Emacs and vim), and they let `generate.sh` abort on the first error for easier and step-by-step debugging.

And thanks for all that XSL foo! Still seems to work fine after all these years and I'd never got to good results that quick otherwise.