### PR TITLE
Add `SCRIPT_DIR` bash var so I can use script outside location

### DIFF
--- a/entities.xsl
+++ b/entities.xsl
@@ -13,6 +13,7 @@ Transform a Confluence XML format space export to multiple xml pages.
   <xsl:param name="output-path" select="'out/'" />
   <xsl:param name="space" select="'storage'" />
   <xsl:param name="space-category" select="'storage-team'" />
+  <xsl:param name="dtd-path" select="'page.dtd'" />
 
   <xsl:template match="@*|node()" priority="-1">
     <xsl:copy>
@@ -55,7 +56,7 @@ Transform a Confluence XML format space export to multiple xml pages.
     -->
     <xsl:variable name="was" select="' \/:*?\|&quot;&lt;&gt;'"/>
     <xsl:variable name="now" select="'-----------'"/>
-    <exsl:document href="{$output-path}/page-xml/{translate(property[@name='title'],$was,$now)}.xml" format="xml" standalone="no" indent="yes" doctype-system="../../page.dtd">
+    <exsl:document href="{$output-path}/page-xml/{translate(property[@name='title'],$was,$now)}.xml" format="xml" standalone="no" indent="yes" doctype-system="{$dtd-path}">
       <page 
         xmlns:ac="http://www.atlassian.com/schema/confluence/4/ac/"
         xmlns:ri="http://www.atlassian.com/schema/confluence/4/ri/"

--- a/generate.sh
+++ b/generate.sh
@@ -13,7 +13,7 @@ mkdir -pv out/page-xml
 mkdir -pv out/wiki/images
 
 echo "Generating page xmls and image mapping"
-xsltproc $SCRIPT_DIR/entities.xsl entities.xml
+xsltproc --stringparam dtd-path "$SCRIPT_DIR/page.dtd" $SCRIPT_DIR/entities.xsl entities.xml
 
 echo "Copying images from attachments"
 xsltproc $SCRIPT_DIR/image-mappings.xsl out/image-mappings.xml | bash

--- a/generate.sh
+++ b/generate.sh
@@ -3,6 +3,9 @@
 # Generate github markdown pages from confluence export
 ########################################################################
 
+# From https://stackoverflow.com/a/246128
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 set -e
 
 echo "Creating output directories"
@@ -10,17 +13,17 @@ mkdir -pv out/page-xml
 mkdir -pv out/wiki/images
 
 echo "Generating page xmls and image mapping"
-xsltproc entities.xsl entities.xml
+xsltproc $SCRIPT_DIR/entities.xsl entities.xml
 
 echo "Copying images from attachments"
-xsltproc image-mappings.xsl out/image-mappings.xml | bash
+xsltproc $SCRIPT_DIR/image-mappings.xsl out/image-mappings.xml | bash
 
 
 echo "Convert page xmls to github markdown"
 for PAGE_PATH in out/page-xml/*.xml; do 
    PAGE_XML=${PAGE_PATH##out/page-xml/}
    PAGE_MD=${PAGE_XML%%.xml}.md
-   xsltproc --path . page.xsl "${PAGE_PATH}" > "out/wiki/${PAGE_MD}"
+   xsltproc --path . $SCRIPT_DIR/page.xsl "${PAGE_PATH}" > "out/wiki/${PAGE_MD}"
 done
 
 echo "Content generated to out/wiki"


### PR DESCRIPTION
So I can use where Confluence content exports live, but keep this outside. E.g.

```bash
cd ~/export-of-unzipped-confluence-xml-export-content
 ~/Scripts/confluence-to-github/generate.sh
```